### PR TITLE
Added animation when inserting item in history

### DIFF
--- a/src/components/HistorySection.vue
+++ b/src/components/HistorySection.vue
@@ -21,7 +21,7 @@ defineProps({
         v-for="items in history"
         :key="items"
       >
-        <div class="grid grid-cols-5 self-center place-content-center">
+        <div class="grid grid-cols-5 self-center place-content-center animate-slide-in">
           <div
             v-for="fruit in items.selectedFruits"
             :key="fruit"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,7 +11,22 @@ module.exports = {
     extend: {
       fontFamily: {
         sans: ['Inter var', ...defaultTheme.fontFamily.sans],
-      }
+      },
+      keyframes: {
+        'slide-in': {
+          '0%': {
+            opacity: '0',
+            transform: 'translateY(-10px)',
+          },
+          '100%': {
+            opacity: '1',
+            transform: 'translateY(0)',
+          },
+        },
+      },
+      animation: {
+        'slide-in': 'slide-in 1s ease 0s 1 normal forwards',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
### What
 - [x] Added animation when inserting an item in history.
 
 ### How
 - Added a custom keyframe and animation in tailwind.config.js
 ```js
 keyframes: {
        'slide-in': {
          '0%': {
            opacity: '0',
            transform: 'translateY(-10px)',
          },
          '100%': {
            opacity: '1',
            transform: 'translateY(0)',
          },
        },
      },
      animation: {
        'slide-in': 'slide-in 1s ease 0s 1 normal forwards',
      },
 ```
- Used the custom animation on the history item container

```diff
-      <div class="grid grid-cols-5 self-center place-content-center">
+      <div class="grid grid-cols-5 self-center place-content-center animate-slide-in">
```